### PR TITLE
add taskName to reserved attributes

### DIFF
--- a/src/logfmter/formatter.py
+++ b/src/logfmter/formatter.py
@@ -33,6 +33,7 @@ RESERVED: Tuple[str, ...] = (
     "processName",
     "relativeCreated",
     "stack_info",
+    "taskName",
     "thread",
     "threadName",
 )


### PR DESCRIPTION
Python 3.12 has added `taskName` attribute to `LogRecord`. This adds its to the list of reserved attributes.

Doc from the specific release: https://docs.python.org/3.12/library/logging.html#logrecord-attributes