### PR TITLE
Pyright Fix: Requires Re-Export

### DIFF
--- a/src/logfmter/__init__.py
+++ b/src/logfmter/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 
-from logfmter.formatter import Logfmter
+from logfmter.formatter import Logfmter as Logfmter
 
 __version__ = "0.0.8"


### PR DESCRIPTION
Re-exports the `Logfmter` class in `__init__.py` to resolve any pyright issues.

**Issues**
Resolves #16